### PR TITLE
Force allocation-ratios to be float in nova-cloud-controller

### DIFF
--- a/bundle-pike.yaml
+++ b/bundle-pike.yaml
@@ -219,8 +219,8 @@ services:
       worker-multiplier: 0.1
       network-manager: Neutron
       openstack-origin: cloud:xenial-pike
-      ram-allocation-ratio: 64
-      cpu-allocation-ratio: 64
+      ram-allocation-ratio: 64.1
+      cpu-allocation-ratio: 64.1
   nova-compute:
     annotations:
       gui-x: '250'


### PR DESCRIPTION
solves issue #28 
issue happens because of bug https://bugs.launchpad.net/juju/+bug/1613839
bundle deployment does not accept "1.0" as valid float