### PR TITLE
The container's root device is missing the pool property

### DIFF
--- a/lxd-2.2.x-profile.yaml
+++ b/lxd-2.2.x-profile.yaml
@@ -1,0 +1,32 @@
+name: juju-default
+config:
+  boot.autostart: "true"
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+devices:
+  eth0:
+    mtu: "9000"
+    name: eth0
+    nictype: bridged
+    parent: lxdbr0
+    type: nic
+  eth1:
+    mtu: "9000"
+    name: eth1
+    nictype: bridged
+    parent: lxdbr0
+    type: nic
+  kvm:
+    path: /dev/kvm
+    type: unix-char
+  mem:
+    path: /dev/mem
+    type: unix-char
+  root:
+    path: /
+    type: disk
+    pool: default
+  tun:
+    path: /dev/net/tun
+    type: unix-char


### PR DESCRIPTION
Added pool key to the root device having the value of the default LXD pool name.