### PR TITLE
Stick with Juju stable releases

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,2 @@
 default-series: xenial
-agent-stream: devel
 apt-http-proxy: http://10.0.8.1:8000


### PR DESCRIPTION
Corresponding to the change in charm-guide.
https://review.openstack.org/#/c/548600/

Previously ppa:juju/devel was required when Juju 2.x was not officially released. Now stable releases of Juju 2.x are mature enough to be relied on as a base of charm development.