### PR TITLE
removed sources from ceph-mon and added nameservers to designate

### DIFF
--- a/bundle-bionic-queens.yaml
+++ b/bundle-bionic-queens.yaml
@@ -124,7 +124,6 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: cloud:xenial-queens
   ceph-osd:
     annotations:
       gui-x: '1000'
@@ -134,7 +133,6 @@ services:
     options:
       osd-devices: /srv/osd
       use-direct-io: False
-      source: cloud:xenial-queens
   ceph-radosgw:
     annotations:
       gui-x: '1000'
@@ -161,6 +159,8 @@ services:
   designate:
     charm: cs:designate
     num_units: 1
+    options:
+      nameservers: 'ns1.example.com ns2.example.com'
   designate-bind:
     charm: cs:designate-bind
     num_units: 1


### PR DESCRIPTION
Fixes #45 .  the nameservers seem to work but not allow for actually using the DNS functions in openstack, not sure if that field is asking for existing nameservers or providing names for the nameservers that get created so I just used the sample text for the designate charm.  Happy to make any changes you like.