### PR TITLE
Resolve ambiguous relation between ceilometer and rabbitmq-server…

### DIFF
--- a/bundle-xenial-mitaka.yaml
+++ b/bundle-xenial-mitaka.yaml
@@ -75,8 +75,8 @@ relations:
   - rabbitmq-server
 - - ceilometer
   - keystone:identity-service
-- - ceilometer
-  - rabbitmq-server
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
 - - ceilometer
   - mongodb
 - - ceilometer-agent

--- a/bundle-xenial-newton.yaml
+++ b/bundle-xenial-newton.yaml
@@ -75,8 +75,8 @@ relations:
   - rabbitmq-server
 - - ceilometer
   - keystone:identity-service
-- - ceilometer
-  - rabbitmq-server
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
 - - ceilometer
   - mongodb
 - - ceilometer-agent

--- a/bundle-xenial-ocata.yaml
+++ b/bundle-xenial-ocata.yaml
@@ -75,8 +75,8 @@ relations:
   - rabbitmq-server
 - - ceilometer
   - keystone:identity-service
-- - ceilometer
-  - rabbitmq-server
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
 - - ceilometer
   - mongodb
 - - ceilometer-agent

--- a/bundle-xenial-pike.yaml
+++ b/bundle-xenial-pike.yaml
@@ -75,8 +75,8 @@ relations:
   - rabbitmq-server
 - - ceilometer
   - keystone:identity-service
-- - ceilometer
-  - rabbitmq-server
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
 - - ceilometer
   - mongodb
 - - ceilometer-agent


### PR DESCRIPTION
… for pre-Queens deploys on Xenial (fix already present for xenial-queens and bionic-*)

Without this fix, attempting to deploy e.g. xenial-mitaka will fail with:

ERROR cannot deploy bundle: cannot add relation between "ceilometer" and "rabbitmq-server": ambiguous relation: "ceilometer rabbitmq-server" could refer to "ceilometer:amqp rabbitmq-server:amqp"; "ceilometer:amqp-listener rabbitmq-server:amqp"
