### PR TITLE
 fix ceph-disk prepare fails inside lxd deployment

### DIFF
--- a/bundle-bionic-queens.yaml
+++ b/bundle-bionic-queens.yaml
@@ -133,6 +133,7 @@ services:
     options:
       osd-devices: /srv/osd
       use-direct-io: False
+      bluestore: False
   ceph-radosgw:
     annotations:
       gui-x: '1000'

--- a/bundle-bionic-rocky.yaml
+++ b/bundle-bionic-rocky.yaml
@@ -135,6 +135,7 @@ services:
       osd-devices: /srv/osd
       use-direct-io: False
       source: cloud:bionic-rocky
+      bluestore: False
   ceph-radosgw:
     annotations:
       gui-x: '1000'

--- a/bundle-xenial-queens.yaml
+++ b/bundle-xenial-queens.yaml
@@ -135,6 +135,7 @@ services:
       osd-devices: /srv/osd
       use-direct-io: False
       source: cloud:xenial-queens
+      bluestore: False
   ceph-radosgw:
     annotations:
       gui-x: '1000'


### PR DESCRIPTION
Bluestore is not supported with ZFS

Close-Bug: #1794512
Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@canonical.com>