### PR TITLE
Fix ceilometer-agent blocking and neutron-gateway

### DIFF
--- a/bundle-bionic-queens.yaml
+++ b/bundle-bionic-queens.yaml
@@ -83,6 +83,8 @@ relations:
   - keystone:identity-notifications
 - - ceilometer-agent:nova-ceilometer
   - nova-compute:nova-ceilometer
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
 - - gnocchi:storage-ceph
   - ceph-mon:client
 - - gnocchi:shared-db
@@ -227,8 +229,9 @@ services:
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
-      data-port: br-ex:eth1
+      data-port: br-ex:eth0 br-data:eth0
       worker-multiplier: 0.1
+      sysctl: ""
   neutron-openvswitch:
     annotations:
       gui-x: '250'

--- a/bundle-bionic-queens.yaml
+++ b/bundle-bionic-queens.yaml
@@ -229,7 +229,7 @@ services:
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
-      data-port: br-ex:eth0 br-data:eth0
+      data-port: br-ex:eth1
       worker-multiplier: 0.1
       sysctl: ""
   neutron-openvswitch:

--- a/openrc
+++ b/openrc
@@ -1,8 +1,9 @@
-_keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
-_keystone_major_version=$(juju status ${_keystone_unit} --format yaml| \
+if [ ! -z $JUJU_MODEL ]; then
+  _juju_model_arg="-m $JUJU_MODEL"
+fi
+_keystone_major_version=$(juju status $_juju_model_arg keystone --format yaml| \
     awk '/^    version:/ {print $2; exit}' | cut -f1 -d\.)
-_keystone_preferred_api_version=$(juju config keystone preferred-api-version)
+_keystone_preferred_api_version=$(juju config $_juju_model_arg keystone preferred-api-version)
 
 if [ $_keystone_major_version -ge 13 -o \
      "$_keystone_preferred_api_version" = '3' ]; then

--- a/openrcv2
+++ b/openrcv2
@@ -5,10 +5,8 @@ for param in $_OS_PARAMS; do
     unset $param
 done
 
-_keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
-_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
-_password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
 unset _OS_PARAMS
 export OS_USERNAME=admin

--- a/openrcv3_domain
+++ b/openrcv3_domain
@@ -6,10 +6,8 @@ for param in $_OS_PARAMS; do
 done
 unset _OS_PARAMS
 
-_keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
-_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
-_password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
 export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
 export OS_USERNAME=admin

--- a/openrcv3_project
+++ b/openrcv3_project
@@ -6,10 +6,8 @@ for param in $_OS_PARAMS; do
 done
 unset _OS_PARAMS
 
-_keystone_unit=$(juju status keystone --format yaml | \
-    awk '/units:$/ {getline; gsub(/:$/, ""); print $1; exit}')
-_keystone_ip=$(juju run --unit ${_keystone_unit} 'unit-get private-address')
-_password=$(juju run --unit ${_keystone_unit} 'leader-get admin_passwd')
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
 export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
 export OS_USERNAME=admin


### PR DESCRIPTION
The following adjustments to the bionic-queens bundle solve
a few issues encountered when deploying on LXD. Ceilometer-agent
was being blocked due to missing Messaging relation. Also,
neutron-gateway resulted in an error state due to the sysctl error
as well as the data-port using a device that didn't exist.

- Add ceilometer-agent relation with rabbitmq-server
- Change neutrongw config sysctl to blank string
- Change neutrongw config data-port to br-ex:eth0 br-data:eth0