### PR TITLE
The ceph stuff needs to stay on stein

### DIFF
--- a/bundle-bionic-train.yaml
+++ b/bundle-bionic-train.yaml
@@ -134,7 +134,7 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: cloud:bionic-train
+      source: cloud:bionic-stein
   ceph-osd:
     annotations:
       gui-x: '1000'
@@ -144,7 +144,7 @@ services:
     options:
       osd-devices: /srv/osd
       use-direct-io: False
-      source: cloud:bionic-train
+      source: cloud:bionic-stein
       bluestore: False
   ceph-radosgw:
     annotations:
@@ -153,7 +153,7 @@ services:
     charm: cs:ceph-radosgw
     num_units: 1
     options:
-      source: cloud:bionic-train
+      source: cloud:bionic-stein
   cinder:
     annotations:
       gui-x: '750'

--- a/bundle-eoan-train.yaml
+++ b/bundle-eoan-train.yaml
@@ -134,7 +134,8 @@ services:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: distro
+      source: cloud:bionic-stein
+    series: bionic
   ceph-osd:
     annotations:
       gui-x: '1000'
@@ -144,8 +145,9 @@ services:
     options:
       osd-devices: /srv/osd
       use-direct-io: False
-      source: distro
+      source: cloud:bionic-stein
       bluestore: False
+    series: bionic
   ceph-radosgw:
     annotations:
       gui-x: '1000'
@@ -153,7 +155,8 @@ services:
     charm: cs:ceph-radosgw
     num_units: 1
     options:
-      source: distro
+      source: cloud:bionic-stein
+    series: bionic
   cinder:
     annotations:
       gui-x: '750'
@@ -218,6 +221,7 @@ services:
       gui-y: '500'
     charm: cs:memcached
     num_units: 1
+    series: bionic
   mysql:
     annotations:
       gui-x: '0'


### PR DESCRIPTION
The new version of ceph (Nautilus) does not support directory
backed OSDs, so to continue to support this feature we use
bionic stein instead

closes #72 