### PR TITLE
Add openstack-origin to ceilometer

### DIFF
--- a/bundle-bionic-rocky.yaml
+++ b/bundle-bionic-rocky.yaml
@@ -116,6 +116,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:bionic-rocky
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph-mon:

--- a/bundle-bionic-stein.yaml
+++ b/bundle-bionic-stein.yaml
@@ -116,6 +116,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:bionic-stein
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph-mon:

--- a/bundle-xenial-newton.yaml
+++ b/bundle-xenial-newton.yaml
@@ -100,6 +100,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:xenial-newton
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph:

--- a/bundle-xenial-ocata.yaml
+++ b/bundle-xenial-ocata.yaml
@@ -100,6 +100,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:xenial-ocata
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph:

--- a/bundle-xenial-pike.yaml
+++ b/bundle-xenial-pike.yaml
@@ -100,6 +100,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:xenial-pike
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph:

--- a/bundle-xenial-queens.yaml
+++ b/bundle-xenial-queens.yaml
@@ -116,6 +116,8 @@ services:
   ceilometer:
     charm: cs:ceilometer
     num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
   ceilometer-agent:
     charm: cs:ceilometer-agent
   ceph-mon:


### PR DESCRIPTION
Missing bundle option causes ceilometer to be
installed from the distro version, which in
some cases will be different than the
current openstack version (example: xenial-queens)

Added the option to several bundles where it
makes sense.

closes #76 