### PR TITLE
fix the `OS_AUTH_PROTOCOL` setting on https

### DIFF
--- a/openrcv3_domain
+++ b/openrcv3_domain
@@ -12,7 +12,7 @@ else
 fi
 _password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
-if [ -s $_root_ca ]; then
+if [ ! -z "$_root_ca" -a -s "$_root_ca" ]; then
     export OS_AUTH_PROTOCOL=https
     export OS_CACERT=${_root_ca}
 fi

--- a/openrcv3_project
+++ b/openrcv3_project
@@ -12,7 +12,7 @@ else
 fi
 _password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
-if [ -s $_root_ca ]; then
+if [ ! -z "$_root_ca" -a -s "$_root_ca" ]; then
     export OS_AUTH_PROTOCOL=https
     export OS_CACERT=${_root_ca}
 fi


### PR DESCRIPTION
If the variable `_root_ca` is not present, then this condition should not
set `OS_AUTH_PROTOCOL` to https.

Added a test to verify the presence of the `_root_ca` variable.

closes: #78 