### PR TITLE
bundle-bionic-ussuri.yaml: relations defined more than once

### DIFF
--- a/bundle-bionic-ussuri.yaml
+++ b/bundle-bionic-ussuri.yaml
@@ -117,12 +117,6 @@ relations:
   - designate:coordinator-memcached
 - - ceph-osd:mon
   - ceph-mon:osd
-- - neutron-gateway:amqp
-  - rabbitmq-server:amqp
-- - neutron-gateway:neutron-plugin-api
-  - neutron-api:neutron-plugin-api
-- - nova-cloud-controller:quantum-network-service
-  - neutron-gateway:quantum-network-service
 series: bionic
 services:
   ceilometer:


### PR DESCRIPTION
I got error when deploy this bundle:

juju deploy ./bundle-bionic-ussuri.yaml
ERROR cannot deploy bundle: the provided bundle has the following errors:
relation ["neutron-gateway:amqp" "rabbitmq-server:amqp"] is defined more than once
relation ["neutron-gateway:neutron-plugin-api" "neutron-api:neutron-plugin-api"] is defined more than once
relation ["nova-cloud-controller:quantum-network-service" "neutron-gateway:quantum-network-service"] is defined more than once

this patch removed above duplicated relations in bundle.

Signed-off-by: Joe Guo <joe.guo@canonical.com>